### PR TITLE
Fix dtype cast to integer

### DIFF
--- a/python/audioprocess.py
+++ b/python/audioprocess.py
@@ -154,7 +154,7 @@ class agc():
       self._valbuf = np.zeros(self._valbufsize,dtype=np.float32)
       self._ind = np.add.outer(
          agcbufsize*np.arange(self._magbufsize-agcbufsize+1),
-         (agcbufsize+1)*np.arange(agcbufsize)).astype(np.integer)
+         (agcbufsize+1)*np.arange(agcbufsize)).astype(int)
 
    def process(self,buf):
       """


### PR DESCRIPTION
A dtype cast to np.integer seems to be disallowed in newer Python/NumPy versions. Therefore, change cast from `np.integer` to `int`.
Running Python 3.13 with NumPy 2.3.2 here.

Shown error:
```
Traceback (most recent call last):
  File "/home/max/apps/cwsim/python/cwsim.py", line 1164, in <module>
    form = RunApp()
  File "/home/max/apps/cwsim/python/cwsim.py", line 84, in __init__
    self.contest = Contest(np.random.default_rng(),inifile=self.defaultini)
                   ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/max/apps/cwsim/python/contest.py", line 95, in __init__
    self._m5 = agc(self._bufsize)
               ~~~^^^^^^^^^^^^^^^
  File "/home/max/apps/cwsim/python/audioprocess.py", line 157, in __init__
    (agcbufsize+1)*np.arange(agcbufsize)).astype(np.integer)
                                          ~~~~~~^^^^^^^^^^^^
TypeError: Converting 'np.integer' or 'np.signedinteger' to a dtype is not allowed
```